### PR TITLE
feat: optionally compress output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1005,6 +1005,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a08173bc88b7955d1b3145aa561539096c421ac8debde8cbc3612ec635fee29b"
 
 [[package]]
+name = "liblzma"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7c45fc6fcf5b527d3cf89c1dee8c327943984b0dc8bfcf6e100473b00969e63"
+dependencies = [
+ "liblzma-sys",
+ "num_cpus",
+]
+
+[[package]]
+name = "liblzma-sys"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "885d379719f1be90c51852451dc658009c1aab2eb867cae8d5eb7f83bfaaca96"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "libredox"
 version = "0.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1106,6 +1127,7 @@ dependencies = [
  "futures-util",
  "indicatif",
  "lazy_static",
+ "liblzma",
  "log",
  "md5",
  "reqwest",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -311,11 +311,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
 
 [[package]]
+name = "bzip2"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdb116a6ef3f6c3698828873ad02c3014b3c85cadb88496095628e3ef1e347f8"
+dependencies = [
+ "bzip2-sys",
+ "libc",
+]
+
+[[package]]
+name = "bzip2-sys"
+version = "0.1.11+1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "736a955f3fa7875102d57c82b8cac37ec45224a07fd32d58f9f7a186b6cd4cdc"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "cc"
 version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
 dependencies = [
+ "jobserver",
  "libc",
 ]
 
@@ -944,6 +966,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 
 [[package]]
+name = "jobserver"
+version = "0.1.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1067,6 +1098,7 @@ version = "0.1.1"
 dependencies = [
  "anyhow",
  "async-std",
+ "bzip2",
  "clap",
  "dirs",
  "env_logger",
@@ -1082,6 +1114,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "toml",
+ "zstd",
 ]
 
 [[package]]
@@ -2285,3 +2318,31 @@ name = "zeroize"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+
+[[package]]
+name = "zstd"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcf2b778a664581e31e389454a7072dab1647606d44f7feea22cd5abb9c9f3f9"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54a3ab4db68cea366acc5c897c7b4d4d1b8994a9cd6e6f841f8964566a419059"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.13+zstd.1.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38ff0f21cfee8f97d94cef41359e0c89aa6113028ab0291aa8ca0038995a95aa"
+dependencies = [
+ "cc",
+ "pkg-config",
+]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1194,7 +1194,6 @@ dependencies = [
  "futures-util",
  "gzp",
  "indicatif",
- "lazy_static",
  "liblzma",
  "log",
  "md5",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -305,6 +305,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "bytes"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -333,12 +339,13 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.83"
+version = "1.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
+checksum = "45bcde016d64c21da4be18b655631e5ab6d3107607e71a73a9f53eb48aae23fb"
 dependencies = [
  "jobserver",
  "libc",
+ "shlex",
 ]
 
 [[package]]
@@ -430,6 +437,17 @@ name = "core-foundation-sys"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
+
+[[package]]
+name = "core_affinity"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "622892f5635ce1fc38c8f16dfc938553ed64af482edb5e150bf4caedbfcb2304"
+dependencies = [
+ "libc",
+ "num_cpus",
+ "winapi",
+]
 
 [[package]]
 name = "crc32fast"
@@ -589,6 +607,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "flume"
+version = "0.10.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1657b4441c3403d9f7b3409e47575237dac27b1b5726df654a6ecbf92f0f7577"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "nanorand",
+ "pin-project",
+ "spin",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -716,8 +747,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe9006bed769170c11f845cf00c7c1e9092aeb3f268e007c3e760ac68008070f"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -736,6 +769,21 @@ dependencies = [
  "futures-core",
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "gzp"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c65d1899521a11810501b50b898464d133e1afc96703cff57726964cfa7baf"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "core_affinity",
+ "flate2",
+ "flume",
+ "num_cpus",
+ "thiserror",
 ]
 
 [[package]]
@@ -1049,6 +1097,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da2479e8c062e40bf0066ffa0bc823de0a9368974af99c9f6df941d2c231e03f"
 
 [[package]]
+name = "lock_api"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1096,6 +1154,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "nanorand"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
 name = "native-tls"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1125,6 +1192,7 @@ dependencies = [
  "env_logger",
  "flate2",
  "futures-util",
+ "gzp",
  "indicatif",
  "lazy_static",
  "liblzma",
@@ -1543,6 +1611,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
 name = "security-framework"
 version = "2.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1618,6 +1692,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1657,6 +1737,9 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
 
 [[package]]
 name = "strsim"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,3 +36,4 @@ async-std = { version = "1.12.0", features = ["attributes", "tokio1"] }
 indicatif = "0.17.7"
 bzip2 = "0.4.4"
 zstd = { version = "0.13.2", features = ["zstdmt"] }
+liblzma = { version = "0.3.4", features = ["parallel"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,3 +37,4 @@ indicatif = "0.17.7"
 bzip2 = "0.4.4"
 zstd = { version = "0.13.2", features = ["zstdmt"] }
 liblzma = { version = "0.3.4", features = ["parallel"] }
+gzp = { version = "0.11.3", default-features = false, features = ["deflate_rust"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/mbhall88/nohuman"
 homepage = "https://github.com/mbhall88/nohuman"
 readme = "README.md"
 license-file = "LICENSE"
-rust-version = "1.70.0"
+rust-version = "1.80.0"
 keywords = ["bioinformatics", "contamination", "metagenomics"]
 categories = ["science", "command-line-utilities"]
 
@@ -29,7 +29,6 @@ tempfile = "3.8.1"
 toml = "0.8.8"
 serde = { version = "1.0.193", features = ["derive"] }
 md5 = "0.7.0"
-lazy_static = "1.4.0"
 dirs = "5.0.1"
 futures-util = "0.3.29"
 async-std = { version = "1.12.0", features = ["attributes", "tokio1"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,3 +34,5 @@ dirs = "5.0.1"
 futures-util = "0.3.29"
 async-std = { version = "1.12.0", features = ["attributes", "tokio1"] }
 indicatif = "0.17.7"
+bzip2 = "0.4.4"
+zstd = { version = "0.13.2", features = ["zstdmt"] }

--- a/README.md
+++ b/README.md
@@ -6,27 +6,30 @@
 [![github release version](https://img.shields.io/github/v/release/mbhall88/nohuman)](https://github.com/mbhall88/nohuman/releases)
 [![DOI:10.1093/gigascience/giae010](https://img.shields.io/badge/citation-10.1093/gigascience/giae010-blue)][paper]
 
+👤🧬🚫 **Remove human reads from a sequencing run** 👤🧬️🚫
 
-👤➡️🚫 **Remove human reads from a sequencing run** 👤➡️🚫
-
-`nohuman` removes human reads from sequencing reads by classifying them with [kraken2][kraken] against a custom database built from all of the genomes in the Human Pangenome Reference Consortium's (HPRC) [first draft human pangenome reference](https://doi.org/10.1038/s41586-023-05896-x). It can take any type of sequencing technology. Read more about the development of this method [here][paper].
+`nohuman` removes human reads from sequencing reads by classifying them with [kraken2][kraken] against a custom database
+built from all of the genomes in the Human Pangenome Reference Consortium's (
+HPRC) [first draft human pangenome reference](https://doi.org/10.1038/s41586-023-05896-x). It can take any type of
+sequencing technology. Read more about the development of this method [here][paper].
 
 - [NoHuman](#nohuman)
-  - [Install](#install)
-    - [Conda (recommended)](#conda-recommended)
-    - [Precompiled binary](#precompiled-binary)
-    - [Cargo](#cargo)
-    - [Container](#container)
-      - [`singularity`](#singularity)
-      - [`docker`](#docker)
-    - [Build from source](#build-from-source)
-  - [Usage](#usage)
-    - [Download the database](#download-the-database)
-    - [Check dependecies are available](#check-dependecies-are-available)
-    - [Remove human reads](#remove-human-reads)
-    - [Full usage](#full-usage)
-  - [Alternates](#alternates)
-  - [Cite](#cite)
+    - [Install](#install)
+        - [Conda (recommended)](#conda-recommended)
+        - [Precompiled binary](#precompiled-binary)
+        - [Cargo](#cargo)
+        - [Container](#container)
+            - [`singularity`](#singularity)
+            - [`docker`](#docker)
+        - [Build from source](#build-from-source)
+    - [Usage](#usage)
+        - [Download the database](#download-the-database)
+        - [Check dependecies are available](#check-dependecies-are-available)
+        - [Remove human reads](#remove-human-reads)
+        - [Keep human reads](#keep-human-reads)
+        - [Full usage](#full-usage)
+    - [Alternates](#alternates)
+    - [Cite](#cite)
 
 ## Install
 
@@ -39,7 +42,6 @@
 ```shell
 $ conda install -c bioconda nohuman
 ```
-
 
 ### Precompiled binary
 
@@ -82,7 +84,6 @@ Options
         -h, --help
                 Display this help message
 ```
-
 
 ### Cargo
 
@@ -137,7 +138,6 @@ $ cargo build --release
 $ target/release/nohuman -h
 ```
 
-
 ## Usage
 
 ### Download the database
@@ -146,7 +146,8 @@ $ target/release/nohuman -h
 $ nohuman -d
 ```
 
-by default, this will place the database in `$HOME/.nohuman/db`. If you want to download it somewhere else, use the `--db` option.
+by default, this will place the database in `$HOME/.nohuman/db`. If you want to download it somewhere else, use
+the `--db` option.
 
 ### Check dependencies are available
 
@@ -177,15 +178,21 @@ $ nohuman -t 4 in_1.fq in_2.fq
 
 or to specify a different path for the output
 
-
 ```
 $ nohuman -t 4 --out1 clean_1.fq --out2 clean_2.fq in_1.fq in_2.fq
 ```
 
-Compressed output will be inferred from the specified output path(s). If no output path is provided, the same compression 
-as the input will be used. To override the output compression format, use the `--output-type` option. Supported compression 
-formats are gzip (`.gz`), zstandard (`zst`), bzip2 (`.bz2`), and xz (`.xz`). If multiple threads are provided, these will 
+Compressed output will be inferred from the specified output path(s). If no output path is provided, the same
+compression
+as the input will be used. To override the output compression format, use the `--output-type` option. Supported
+compression
+formats are gzip (`.gz`), zstandard (`zst`), bzip2 (`.bz2`), and xz (`.xz`). If multiple threads are provided, these
+will
 be used for compression of the output (where possible).
+
+### Keep human reads
+
+You can invert the functionality of `nohuman` to keep only the human reads by using the `--human/-H` flag.
 
 ```
 $ nohuman -h
@@ -197,13 +204,14 @@ Arguments:
   [INPUT]...  Input file(s) to remove human reads from
 
 Options:
-  -o, --out1 <OUTPUT_1>       First output file
-  -O, --out2 <OUTPUT_2>       Second output file
-  -c, --check                 Check that all required dependencies are available
+  -o, --out1 <OUTPUT_1>       First output file.
+  -O, --out2 <OUTPUT_2>       Second output file.
+  -c, --check                 Check that all required dependencies are available and exit
   -d, --download              Download the database
-  -D, --db <PATH>             Path to the database [default: ~/.nohuman/db]
+  -D, --db <PATH>             Path to the database [default: /home/michael/.nohuman/db]
   -F, --output-type <FORMAT>  Output compression format. u: uncompressed; b: Bzip2; g: Gzip; x: Xz (Lzma); z: Zstd
   -t, --threads <INT>         Number of threads to use in kraken2 and optional output compression. Cannot be 0 [default: 1]
+  -H, --human                 Output human reads instead of removing them
   -v, --verbose               Set the logging level to verbose
   -h, --help                  Print help (see more with '--help')
   -V, --version               Print version
@@ -230,7 +238,7 @@ Options:
           Compression of the output file is determined by the file extension of the output file name.
           Or by using the `--output-type` option. If no output path is given, the same compression
           as the input file will be used.
- 
+
   -O, --out2 <OUTPUT_2>
           Second output file.
 
@@ -241,7 +249,7 @@ Options:
           as the input file will be used.
 
   -c, --check
-          Check that all required dependencies are available and exit.
+          Check that all required dependencies are available and exit
 
   -d, --download
           Download the database
@@ -262,6 +270,9 @@ Options:
 
           [default: 1]
 
+  -H, --human
+          Output human reads instead of removing them
+
   -v, --verbose
           Set the logging level to verbose
 
@@ -274,13 +285,16 @@ Options:
 
 ## Alternates
 
-[Hostile](https://github.com/bede/hostile) is an alignment-based approach that performs well. It take longer and uses more memory than the `nohuman` kraken approach, but has slightly better accuracy for Illumina data. See the [paper] for more details and for other alternate approaches.
+[Hostile](https://github.com/bede/hostile) is an alignment-based approach that performs well. It take longer and uses
+more memory than the `nohuman` kraken approach, but has slightly better accuracy for Illumina data. See the [paper] for
+more details and for other alternate approaches.
 
 ## Cite
 
 [![DOI:10.1093/gigascience/giae010](https://img.shields.io/badge/citation-10.1093/gigascience/giae010-blue)][paper]
 
-> Hall, Michael B., and Lachlan J. M. Coin. “Pangenome databases improve host removal and mycobacteria classification from clinical metagenomic data” GigaScience, April 4, 2024. <https://doi.org/10.1093/gigascience/giae010>
+> Hall, Michael B., and Lachlan J. M. Coin. “Pangenome databases improve host removal and mycobacteria classification
+> from clinical metagenomic data” GigaScience, April 4, 2024. <https://doi.org/10.1093/gigascience/giae010>
 
 ```bibtex
 @article{hall_pangenome_2024,

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ sequencing technology. Read more about the development of this method [here][pap
         - [Build from source](#build-from-source)
     - [Usage](#usage)
         - [Download the database](#download-the-database)
-        - [Check dependecies are available](#check-dependecies-are-available)
+        - [Check dependencies are available](#check-dependencies-are-available)
         - [Remove human reads](#remove-human-reads)
         - [Keep human reads](#keep-human-reads)
         - [Full usage](#full-usage)
@@ -218,7 +218,7 @@ Options:
 ### Full usage
 
 ```
-$nohuman --help
+$ nohuman --help
 Remove human reads from a sequencing run
 
 Usage: nohuman [OPTIONS] [INPUT]...
@@ -255,7 +255,7 @@ Options:
   -D, --db <PATH>
           Path to the database
 
-          [default: /home/michael/.nohuman/db]
+          [default: ~/.nohuman/db]
 
   -F, --output-type <FORMAT>
           Output compression format. u: uncompressed; b: Bzip2; g: Gzip; x: Xz (Lzma); z: Zstd

--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ Arguments:
 
 Options:
   -o, --out1 <OUTPUT_1>       First output file
-  -O, --out2 <OUTPUT_2>       Second output file - if two input files given
+  -O, --out2 <OUTPUT_2>       Second output file
   -c, --check                 Check that all required dependencies are available
   -d, --download              Download the database
   -D, --db <PATH>             Path to the database [default: ~/.nohuman/db]
@@ -232,7 +232,7 @@ Options:
           as the input file will be used.
  
   -O, --out2 <OUTPUT_2>
-          Second output file - if two input files given.
+          Second output file.
 
           Defaults to the name of the first input file with the suffix "nohuman" appended.
           e.g. "input_2.fastq" -> "input_2.nohuman.fq".
@@ -241,7 +241,7 @@ Options:
           as the input file will be used.
 
   -c, --check
-          Check that all required dependencies are available
+          Check that all required dependencies are available and exit.
 
   -d, --download
           Download the database

--- a/README.md
+++ b/README.md
@@ -182,13 +182,11 @@ or to specify a different path for the output
 $ nohuman -t 4 --out1 clean_1.fq --out2 clean_2.fq in_1.fq in_2.fq
 ```
 
-Compressed output will be inferred from the specified output path(s). If no output path is provided, the same
-compression
-as the input will be used. To override the output compression format, use the `--output-type` option. Supported
-compression
-formats are gzip (`.gz`), zstandard (`zst`), bzip2 (`.bz2`), and xz (`.xz`). If multiple threads are provided, these
-will
-be used for compression of the output (where possible).
+> [!TIP]
+> Compressed output will be inferred from the specified output path(s). If no output path is provided, the same
+> compression as the input will be used. To override the output compression format, use the `--output-type` option. 
+> Supported compression formats are gzip (`.gz`), zstandard (`zst`), bzip2 (`.bz2`), and xz (`.xz`). If multiple threads are provided, these
+> will be used for compression of the output (where possible).
 
 ### Keep human reads
 

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ $ nohuman -d
 
 by default, this will place the database in `$HOME/.nohuman/db`. If you want to download it somewhere else, use the `--db` option.
 
-### Check dependecies are available
+### Check dependencies are available
 
 ```
 $ nohuman -c
@@ -182,7 +182,10 @@ or to specify a different path for the output
 $ nohuman -t 4 --out1 clean_1.fq --out2 clean_2.fq in_1.fq in_2.fq
 ```
 
-Note: output will always be uncompressed, even if compressed input is provided.
+Compressed output will be inferred from the specified output path(s). If no output path is provided, the same compression 
+as the input will be used. To override the output compression format, use the `--output-type` option. Supported compression 
+formats are gzip (`.gz`), zstandard (`zst`), bzip2 (`.bz2`), and xz (`.xz`). If multiple threads are provided, these will 
+be used for compression of the output (where possible).
 
 ```
 $ nohuman -h
@@ -194,15 +197,16 @@ Arguments:
   [INPUT]...  Input file(s) to remove human reads from
 
 Options:
-  -o, --out1 <OUTPUT_1>  First output file
-  -O, --out2 <OUTPUT_2>  Second output file - if two input files given
-  -c, --check            Check that all required dependencies are available
-  -d, --download         Download the database
-  -D, --db <PATH>        Path to the database [default: /home/mihall/.nohuman/db]
-  -t, --threads <INT>    Number of threads to use in kraken2 [default: 1]
-  -v, --verbose          Set the logging level to verbose
-  -h, --help             Print help (see more with '--help')
-  -V, --version          Print version
+  -o, --out1 <OUTPUT_1>       First output file
+  -O, --out2 <OUTPUT_2>       Second output file - if two input files given
+  -c, --check                 Check that all required dependencies are available
+  -d, --download              Download the database
+  -D, --db <PATH>             Path to the database [default: ~/.nohuman/db]
+  -F, --output-type <FORMAT>  Output compression format. u: uncompressed; b: Bzip2; g: Gzip; x: Xz (Lzma); z: Zstd
+  -t, --threads <INT>         Number of threads to use in kraken2 and optional output compression. Cannot be 0 [default: 1]
+  -v, --verbose               Set the logging level to verbose
+  -h, --help                  Print help (see more with '--help')
+  -V, --version               Print version
 ```
 
 ### Full usage
@@ -221,12 +225,20 @@ Options:
   -o, --out1 <OUTPUT_1>
           First output file.
 
-          Defaults to the name of the first input file with the suffix "nohuman" appended. e.g. "input_1.fastq.gz" -> "input_1.nohuman.fq". NOTE: kraken2 output cannot be compressed, so the output will always be uncompressed.
-
+          Defaults to the name of the first input file with the suffix "nohuman" appended.
+          e.g. "input_1.fastq" -> "input_1.nohuman.fq".
+          Compression of the output file is determined by the file extension of the output file name.
+          Or by using the `--output-type` option. If no output path is given, the same compression
+          as the input file will be used.
+ 
   -O, --out2 <OUTPUT_2>
           Second output file - if two input files given.
 
-          Defaults to the name of the first input file with the suffix "nohuman" appended. e.g. "input_2.fastq.gz" -> "input_2.nohuman.fq". NOTE: kraken2 output cannot be compressed, so the output will always be uncompressed.
+          Defaults to the name of the first input file with the suffix "nohuman" appended.
+          e.g. "input_2.fastq" -> "input_2.nohuman.fq".
+          Compression of the output file is determined by the file extension of the output file name.
+          Or by using the `--output-type` option. If no output path is given, the same compression
+          as the input file will be used.
 
   -c, --check
           Check that all required dependencies are available
@@ -237,10 +249,16 @@ Options:
   -D, --db <PATH>
           Path to the database
 
-          [default: /home/mihall/.nohuman/db]
+          [default: /home/michael/.nohuman/db]
+
+  -F, --output-type <FORMAT>
+          Output compression format. u: uncompressed; b: Bzip2; g: Gzip; x: Xz (Lzma); z: Zstd
+
+          If not provided, the format will be inferred from the given output file name(s), or the
+          format of the input file(s) if no output file name(s) are given.
 
   -t, --threads <INT>
-          Number of threads to use in kraken2
+          Number of threads to use in kraken2 and optional output compression. Cannot be 0
 
           [default: 1]
 

--- a/justfile
+++ b/justfile
@@ -7,6 +7,7 @@ lint:
 # run all tests
 test:
     cargo test -v --all-targets --no-fail-fast
+    cargo test -v --doc --no-fail-fast
 
 # get coverage with tarpaulin
 coverage:

--- a/src/compression.rs
+++ b/src/compression.rs
@@ -1,0 +1,411 @@
+use anyhow::{bail, Context, Result};
+use bzip2::write::BzEncoder;
+use std::fs::File;
+use std::io;
+use std::io::{Read, Seek, SeekFrom, Write};
+use std::path::{Path, PathBuf};
+use std::str::FromStr;
+
+#[derive(Debug, PartialEq, Copy, Clone, Default)]
+pub enum CompressionFormat {
+    Bzip2,
+    Gzip,
+    #[default]
+    None,
+    Xz,
+    Zstd,
+}
+
+impl FromStr for CompressionFormat {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self> {
+        match s.to_lowercase().as_str() {
+            "b" => Ok(CompressionFormat::Bzip2),
+            "g" => Ok(CompressionFormat::Gzip),
+            "x" => Ok(CompressionFormat::Xz),
+            "z" => Ok(CompressionFormat::Zstd),
+            "u" => Ok(CompressionFormat::None),
+            _ => bail!("Invalid compression format: {}", s),
+        }
+    }
+}
+
+impl std::fmt::Display for CompressionFormat {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let format = match self {
+            CompressionFormat::Bzip2 => "bz2",
+            CompressionFormat::Gzip => "gz",
+            CompressionFormat::None => "",
+            CompressionFormat::Xz => "xz",
+            CompressionFormat::Zstd => "zst",
+        };
+        write!(f, "{}", format)
+    }
+}
+
+impl CompressionFormat {
+    pub fn from_reader<R: Read + Seek>(reader: &mut R) -> Result<Self> {
+        detect_compression_format(reader)
+    }
+
+    /// Detect the compression format of a file based on its path extension.
+    pub fn from_path<P: AsRef<Path>>(path: P) -> Result<Self> {
+        let path = path.as_ref();
+        let extension = path.extension().and_then(|s| s.to_str());
+
+        match extension {
+            Some("bz2") => Ok(CompressionFormat::Bzip2),
+            Some("gz") => Ok(CompressionFormat::Gzip),
+            Some("xz") => Ok(CompressionFormat::Xz),
+            Some("zst") | Some("zstd") => Ok(CompressionFormat::Zstd),
+            _ => Ok(CompressionFormat::None),
+        }
+    }
+
+    pub fn is_compressed(&self) -> bool {
+        *self != CompressionFormat::None
+    }
+
+    pub fn add_extension<P: AsRef<Path>>(&self, path: P) -> PathBuf {
+        let mut path_buf = path.as_ref().to_path_buf();
+
+        if !self.is_compressed() {
+            return path_buf;
+        }
+
+        let new_extension = self.to_string();
+        if let Some(existing_extension) = path_buf.extension() {
+            let combined_extension =
+                format!("{}.{}", existing_extension.to_string_lossy(), new_extension);
+            path_buf.set_extension(combined_extension);
+        } else {
+            path_buf.set_extension(new_extension);
+        }
+
+        path_buf
+    }
+
+    pub fn compress<P: AsRef<Path>>(&self, input: P, output: P, threads: usize) -> Result<()> {
+        let mut input_file = File::open(input)?;
+        let mut output_file = File::create(output).context("Failed to create output file")?;
+
+        let result = match self {
+            Self::None => io::copy(&mut input_file, &mut output_file),
+            Self::Bzip2 => bzip2_compress(&mut input_file, &mut output_file),
+            Self::Gzip => gzip_compress(&mut input_file, &mut output_file, threads),
+            Self::Xz => xz_compress(&mut input_file, &mut output_file, threads),
+            Self::Zstd => zstd_compress(&mut input_file, &mut output_file, threads),
+        };
+
+        if let Err(e) = result {
+            bail!("Failed to compress file: {}", e);
+        }
+        Ok(())
+    }
+}
+
+fn bzip2_compress<R, W>(input: &mut R, output: &mut W) -> io::Result<u64>
+where
+    R: Read,
+    W: Write,
+{
+    let mut encoder = BzEncoder::new(output, bzip2::Compression::default());
+    let bytes = io::copy(input, &mut encoder)?;
+    let _ = encoder.finish()?;
+    Ok(bytes)
+}
+
+fn gzip_compress<R, W>(_input: &mut R, _output: &mut W, _threads: usize) -> io::Result<u64>
+where
+    R: Read,
+    W: Write,
+{
+    unimplemented!()
+}
+
+fn xz_compress<R, W>(_input: &mut R, _output: &mut W, _threads: usize) -> io::Result<u64>
+where
+    R: Read,
+    W: Write,
+{
+    unimplemented!()
+}
+
+fn zstd_compress<R, W>(input: &mut R, output: &mut W, threads: usize) -> io::Result<u64>
+where
+    R: Read,
+    W: Write,
+{
+    let mut encoder = zstd::stream::write::Encoder::new(output, zstd::DEFAULT_COMPRESSION_LEVEL)?;
+    encoder.multithread(threads as u32)?;
+
+    let bytes = io::copy(input, &mut encoder)?;
+    let _ = encoder.finish()?;
+    Ok(bytes)
+}
+
+/// Detect the compression format of a file based on its magic number.
+fn detect_compression_format<R: Read + Seek>(reader: &mut R) -> Result<CompressionFormat> {
+    let original_position = reader.stream_position()?;
+
+    // move the reader to the start of the file
+    reader.seek(SeekFrom::Start(0))?;
+
+    let mut magic = [0; 5];
+    reader
+        .read_exact(&mut magic)
+        .context("Failed to read the first five bytes of the file")?;
+
+    let format = match magic {
+        [0x1f, 0x8b, ..] => CompressionFormat::Gzip,
+        [0x42, 0x5a, ..] => CompressionFormat::Bzip2,
+        [0x28, 0xb5, 0x2f, 0xfd, ..] => CompressionFormat::Zstd,
+        [0xfd, 0x37, 0x7a, 0x58, 0x5a] => CompressionFormat::Xz,
+        _ => CompressionFormat::None,
+    };
+
+    // Seek back to the original position
+    reader
+        .seek(SeekFrom::Start(original_position))
+        .context("Failed to return reader to original position")?;
+
+    Ok(format)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Cursor;
+
+    #[test]
+    fn test_detect_gzip_format() {
+        let data = vec![
+            0x1f, 0x8b, 0x08, 0x08, 0x1c, 0x6b, 0xe2, 0x66, 0x00, 0x03, 0x74, 0x65, 0x78, 0x74,
+            0x2e, 0x74, 0x78, 0x74, 0x00, 0x4b, 0xcb, 0xcf, 0x57, 0x48, 0x4a, 0x2c, 0xe2, 0x02,
+            0x00, 0x27, 0xb4, 0xdd, 0x13, 0x08, 0x00, 0x00, 0x00,
+        ];
+        let mut reader = Cursor::new(data);
+        // position the reader at the original position
+        let original_position = reader.position();
+        let format = detect_compression_format(&mut reader).unwrap();
+        assert_eq!(format, CompressionFormat::Gzip);
+        assert_eq!(reader.position(), original_position);
+    }
+
+    #[test]
+    fn test_detect_bzip2_format() {
+        let data = vec![
+            0x42, 0x5a, 0x68, 0x39, 0x31, 0x41, 0x59, 0x26, 0x53, 0x59, 0x7b, 0x6e, 0xa8, 0x38,
+            0x00, 0x00, 0x02, 0x51, 0x80, 0x00, 0x10, 0x40, 0x00, 0x31, 0x00, 0x90, 0x00, 0x20,
+            0x00, 0x22, 0x1a, 0x63, 0x50, 0x86, 0x00, 0x2c, 0x8c, 0x3c, 0x5d, 0xc9, 0x14, 0xe1,
+            0x42, 0x41, 0xed, 0xba, 0xa0, 0xe0,
+        ];
+        let mut reader = Cursor::new(data);
+        // position the reader at the original position
+        let original_position = reader.position();
+        let format = detect_compression_format(&mut reader).unwrap();
+        assert_eq!(format, CompressionFormat::Bzip2);
+        assert_eq!(reader.position(), original_position);
+    }
+
+    #[test]
+    fn test_detect_zstd_format() {
+        let data = vec![
+            0x28, 0xb5, 0x2f, 0xfd, 0x24, 0x08, 0x41, 0x00, 0x00, 0x66, 0x6f, 0x6f, 0x20, 0x62,
+            0x61, 0x72, 0x0a, 0x37, 0x17, 0xa5, 0xec,
+        ];
+        let mut reader = Cursor::new(data);
+        // position the reader at the original position
+        let original_position = reader.position();
+        let format = detect_compression_format(&mut reader).unwrap();
+        assert_eq!(format, CompressionFormat::Zstd);
+        assert_eq!(reader.position(), original_position);
+    }
+
+    #[test]
+    fn test_detect_xz_format() {
+        let data = vec![
+            0xfd, 0x37, 0x7a, 0x58, 0x5a, 0x00, 0x00, 0x04, 0xe6, 0xd6, 0xb4, 0x46, 0x02, 0x00,
+            0x21, 0x01, 0x16, 0x00, 0x00, 0x00, 0x74, 0x2f, 0xe5, 0xa3, 0x01, 0x00, 0x07, 0x66,
+            0x6f, 0x6f, 0x20, 0x62, 0x61, 0x72, 0x0a, 0x00, 0xfd, 0xbb, 0xfb, 0x3b, 0x8e, 0xcc,
+            0x32, 0x13, 0x00, 0x01, 0x20, 0x08, 0xbb, 0x19, 0xd9, 0xbb, 0x1f, 0xb6, 0xf3, 0x7d,
+            0x01, 0x00, 0x00, 0x00, 0x00, 0x04, 0x59, 0x5a,
+        ];
+        let mut reader = Cursor::new(data);
+        // position the reader at the original position
+        let original_position = reader.position();
+        let format = detect_compression_format(&mut reader).unwrap();
+        assert_eq!(format, CompressionFormat::Xz);
+
+        // confirm that the reader is still at the original position
+        assert_eq!(reader.position(), original_position);
+    }
+
+    #[test]
+    fn test_detect_none_format() {
+        let data = b"I'm not compressed";
+        let mut reader = Cursor::new(data);
+        let format = detect_compression_format(&mut reader).unwrap();
+        assert_eq!(format, CompressionFormat::None);
+    }
+
+    #[test]
+    fn test_detect_format_when_reader_is_part_way_through() {
+        let data = vec![
+            0xfd, 0x37, 0x7a, 0x58, 0x5a, 0x00, 0x00, 0x04, 0xe6, 0xd6, 0xb4, 0x46, 0x02, 0x00,
+            0x21, 0x01, 0x16, 0x00, 0x00, 0x00, 0x74, 0x2f, 0xe5, 0xa3, 0x01, 0x00, 0x07, 0x66,
+            0x6f, 0x6f, 0x20, 0x62, 0x61, 0x72, 0x0a, 0x00, 0xfd, 0xbb, 0xfb, 0x3b, 0x8e, 0xcc,
+            0x32, 0x13, 0x00, 0x01, 0x20, 0x08, 0xbb, 0x19, 0xd9, 0xbb, 0x1f, 0xb6, 0xf3, 0x7d,
+            0x01, 0x00, 0x00, 0x00, 0x00, 0x04, 0x59, 0x5a,
+        ];
+        let mut reader = Cursor::new(data);
+        reader.seek(SeekFrom::Start(10)).unwrap();
+        // position the reader at the original position
+        let original_position = reader.position();
+        let format = detect_compression_format(&mut reader).unwrap();
+        assert_eq!(format, CompressionFormat::Xz);
+
+        // confirm that the reader is still at the original position
+        assert_eq!(reader.position(), original_position);
+    }
+
+    #[test]
+    fn test_compression_format_from_str() {
+        let format = "b".parse::<CompressionFormat>().unwrap();
+        assert_eq!(format, CompressionFormat::Bzip2);
+
+        let format = "g".parse::<CompressionFormat>().unwrap();
+        assert_eq!(format, CompressionFormat::Gzip);
+
+        let format = "x".parse::<CompressionFormat>().unwrap();
+        assert_eq!(format, CompressionFormat::Xz);
+
+        let format = "z".parse::<CompressionFormat>().unwrap();
+        assert_eq!(format, CompressionFormat::Zstd);
+
+        let format = "Z".parse::<CompressionFormat>().unwrap();
+        assert_eq!(format, CompressionFormat::Zstd);
+
+        let format = "u".parse::<CompressionFormat>().unwrap();
+        assert_eq!(format, CompressionFormat::None);
+
+        let format = "J".parse::<CompressionFormat>();
+        assert!(format.is_err());
+    }
+
+    #[test]
+    fn test_compression_format_from_path() {
+        let format = CompressionFormat::from_path("file.txt").unwrap();
+        assert_eq!(format, CompressionFormat::None);
+
+        let format = CompressionFormat::from_path("file.txt.gz").unwrap();
+        assert_eq!(format, CompressionFormat::Gzip);
+
+        let format = CompressionFormat::from_path("file.txt.bz2").unwrap();
+        assert_eq!(format, CompressionFormat::Bzip2);
+
+        let format = CompressionFormat::from_path("file.txt.xz").unwrap();
+        assert_eq!(format, CompressionFormat::Xz);
+
+        let format = CompressionFormat::from_path("file.txt.zst").unwrap();
+        assert_eq!(format, CompressionFormat::Zstd);
+
+        let format = CompressionFormat::from_path("file.txt.zstd").unwrap();
+        assert_eq!(format, CompressionFormat::Zstd);
+    }
+
+    #[test]
+    fn test_compression_format_display() {
+        let format = CompressionFormat::Bzip2;
+        assert_eq!(format.to_string(), "bz2");
+
+        let format = CompressionFormat::Gzip;
+        assert_eq!(format.to_string(), "gz");
+
+        let format = CompressionFormat::None;
+        assert_eq!(format.to_string(), "");
+
+        let format = CompressionFormat::Xz;
+        assert_eq!(format.to_string(), "xz");
+
+        let format = CompressionFormat::Zstd;
+        assert_eq!(format.to_string(), "zst");
+    }
+
+    #[test]
+    fn test_compression_format_is_compressed() {
+        let format = CompressionFormat::Bzip2;
+        assert!(format.is_compressed());
+
+        let format = CompressionFormat::Gzip;
+        assert!(format.is_compressed());
+
+        let format = CompressionFormat::None;
+        assert!(!format.is_compressed());
+
+        let format = CompressionFormat::Xz;
+        assert!(format.is_compressed());
+
+        let format = CompressionFormat::Zstd;
+        assert!(format.is_compressed());
+    }
+
+    #[test]
+    fn test_compression_format_add_extension() {
+        let format = CompressionFormat::Bzip2;
+        let path = Path::new("file.txt");
+        let new_path = format.add_extension(path);
+        assert_eq!(new_path, PathBuf::from("file.txt.bz2"));
+
+        let format = CompressionFormat::Gzip;
+        let path = Path::new("file.txt");
+        let new_path = format.add_extension(path);
+        assert_eq!(new_path, PathBuf::from("file.txt.gz"));
+
+        let format = CompressionFormat::None;
+        let path = Path::new("file.txt");
+        let new_path = format.add_extension(path);
+        assert_eq!(new_path, PathBuf::from("file.txt"));
+
+        let format = CompressionFormat::Xz;
+        let path = Path::new("file.txt");
+        let new_path = format.add_extension(path);
+        assert_eq!(new_path, PathBuf::from("file.txt.xz"));
+
+        let format = CompressionFormat::Zstd;
+        let path = Path::new("file.txt");
+        let new_path = format.add_extension(path);
+        assert_eq!(new_path, PathBuf::from("file.txt.zst"));
+    }
+
+    #[test]
+    fn test_bzip2_compress() {
+        let data = b"foo bar\n";
+        let mut reader = Cursor::new(data);
+        let mut writer = Cursor::new(Vec::new());
+        let bytes = bzip2_compress(&mut reader, &mut writer).unwrap();
+        let expected = vec![
+            0x42, 0x5a, 0x68, 0x36, 0x31, 0x41, 0x59, 0x26, 0x53, 0x59, 0x7b, 0x6e, 0xa8, 0x38,
+            0x00, 0x00, 0x02, 0x51, 0x80, 0x00, 0x10, 0x40, 0x00, 0x31, 0x00, 0x90, 0x00, 0x20,
+            0x00, 0x22, 0x1a, 0x63, 0x50, 0x86, 0x00, 0x2c, 0x8c, 0x3c, 0x5d, 0xc9, 0x14, 0xe1,
+            0x42, 0x41, 0xed, 0xba, 0xa0, 0xe0,
+        ];
+        assert_eq!(bytes, data.len() as u64);
+        assert_eq!(writer.into_inner(), expected);
+    }
+
+    #[test]
+    fn test_zstd_compress() {
+        let data = b"foo bar\n";
+        let mut reader = Cursor::new(data);
+        let mut writer = Cursor::new(Vec::new());
+        let bytes = zstd_compress(&mut reader, &mut writer, 4).unwrap();
+        let expected = vec![
+            0x28, 0xb5, 0x2f, 0xfd, 0x24, 0x08, 0x41, 0x00, 0x00, 0x66, 0x6f, 0x6f, 0x20, 0x62,
+            0x61, 0x72, 0x0a, 0x37, 0x17, 0xa5, 0xec,
+        ];
+        assert_eq!(bytes, data.len() as u64);
+        assert_eq!(writer.into_inner(), expected);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod compression;
 pub mod download;
 
 use serde::Deserialize;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,11 +52,12 @@ impl CommandRunner {
             parse_kraken_stderr(&stderr_log).unwrap_or((0, 0, 0));
 
         info!(
-            "{} / {} ({}%) sequences classified as human; keeping {} non-human sequences...",
+            "{} / {} ({:.2}%) sequences classified as human; {} ({:.2}%) as non-human",
             classified,
             total,
-            (classified as f64 / total as f64 * 100.0),
-            unclassified
+            (classified as f64 / total as f64) * 100.0,
+            unclassified,
+            (unclassified as f64 / total as f64) * 100.0
         );
 
         Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,7 +38,7 @@ struct Args {
     /// as the input file will be used.
     #[arg(short, long, name = "OUTPUT_1", verbatim_doc_comment)]
     pub out1: Option<PathBuf>,
-    /// Second output file - if two input files given.
+    /// Second output file.
     ///
     /// Defaults to the name of the first input file with the suffix "nohuman" appended.
     /// e.g. "input_2.fastq" -> "input_2.nohuman.fq".
@@ -48,7 +48,7 @@ struct Args {
     #[arg(short = 'O', long, name = "OUTPUT_2", verbatim_doc_comment)]
     pub out2: Option<PathBuf>,
 
-    /// Check that all required dependencies are available
+    /// Check that all required dependencies are available and exit.
     #[arg(short, long)]
     check: bool,
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,26 +1,23 @@
 use std::num::NonZeroU32;
 use std::path::PathBuf;
+use std::sync::LazyLock;
 
 use anyhow::{bail, Context, Result};
 use clap::Parser;
 use env_logger::Builder;
-use lazy_static::lazy_static;
 use log::{debug, error, info, warn, LevelFilter};
 use nohuman::compression::CompressionFormat;
 use nohuman::{
     check_path_exists, download::download_database, validate_db_directory, CommandRunner,
 };
 
-lazy_static! {
-    static ref DEFAULT_DB_LOCATION: String = {
-        let home = dirs::home_dir().expect("Could not find home directory");
-        home.join(".nohuman")
-            .join("db")
-            .to_str()
-            .unwrap()
-            .to_string()
-    };
-}
+static DEFAULT_DB_LOCATION: LazyLock<String> = LazyLock::new(|| {
+    let home = dirs::home_dir().unwrap_or_default();
+    home.join(".nohuman")
+        .join("db")
+        .to_string_lossy()
+        .to_string()
+});
 
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -262,18 +262,21 @@ fn main() -> Result<()> {
     if outputs.len() == 2 && threads > 1 {
         let mut handles = Vec::new();
         for (input, output) in outputs {
-            let handle =
-                std::thread::spawn(move || output_compression.compress(&input, &output, threads));
+            let handle = std::thread::spawn(move || {
+                info!("Writing output file to: {:?}", &output);
+                output_compression.compress(&input, &output, threads)
+            });
             handles.push(handle);
         }
         for handle in handles {
             handle
                 .join()
-                .map_err(|e| anyhow::anyhow!("Thread panicked: {:?}", e))??;
+                .map_err(|e| anyhow::anyhow!("Thread panicked when writing output: {:?}", e))??;
         }
     } else {
         for (input, output) in outputs {
             output_compression.compress(&input, &output, threads)?;
+            info!("Output file written to: {:?}", &output);
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,20 +26,26 @@ lazy_static! {
 #[command(author, version, about, long_about = None)]
 struct Args {
     /// Input file(s) to remove human reads from
-    #[arg(name = "INPUT", required_unless_present_any = &["check", "download"], value_parser = check_path_exists)]
+    #[arg(name = "INPUT", required_unless_present_any = &["check", "download"], value_parser = check_path_exists, verbatim_doc_comment)]
     input: Option<Vec<PathBuf>>,
 
     /// First output file.
     ///
-    /// Defaults to the name of the first input file with the suffix "nohuman" appended. e.g. "input_1.fastq.gz" -> "input_1.nohuman.fq".
-    /// NOTE: kraken2 output cannot be compressed, so the output will always be uncompressed.
-    #[arg(short, long, name = "OUTPUT_1")]
+    /// Defaults to the name of the first input file with the suffix "nohuman" appended.
+    /// e.g. "input_1.fastq" -> "input_1.nohuman.fq".
+    /// Compression of the output file is determined by the file extension of the output file name.
+    /// Or by using the `--output-type` option. If no output path is given, the same compression
+    /// as the input file will be used.
+    #[arg(short, long, name = "OUTPUT_1", verbatim_doc_comment)]
     pub out1: Option<PathBuf>,
     /// Second output file - if two input files given.
     ///
-    /// Defaults to the name of the first input file with the suffix "nohuman" appended. e.g. "input_2.fastq.gz" -> "input_2.nohuman.fq".
-    /// NOTE: kraken2 output cannot be compressed, so the output will always be uncompressed.
-    #[arg(short = 'O', long, name = "OUTPUT_2")]
+    /// Defaults to the name of the first input file with the suffix "nohuman" appended.
+    /// e.g. "input_2.fastq" -> "input_2.nohuman.fq".
+    /// Compression of the output file is determined by the file extension of the output file name.
+    /// Or by using the `--output-type` option. If no output path is given, the same compression
+    /// as the input file will be used.
+    #[arg(short = 'O', long, name = "OUTPUT_2", verbatim_doc_comment)]
     pub out2: Option<PathBuf>,
 
     /// Check that all required dependencies are available
@@ -58,10 +64,10 @@ struct Args {
     ///
     /// If not provided, the format will be inferred from the given output file name(s), or the
     /// format of the input file(s) if no output file name(s) are given.
-    #[clap(short = 'F', long, value_name = "FORMAT")]
+    #[clap(short = 'F', long, value_name = "FORMAT", verbatim_doc_comment)]
     pub output_type: Option<CompressionFormat>,
 
-    /// Number of threads to use in kraken2 and optional output compression. Must >0.
+    /// Number of threads to use in kraken2 and optional output compression. Cannot be 0.
     #[arg(short, long, value_name = "INT", default_value = "1")]
     threads: NonZeroU32,
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+use std::num::NonZeroU32;
 use std::path::PathBuf;
 
 use anyhow::{bail, Context, Result};
@@ -60,9 +61,9 @@ struct Args {
     #[clap(short = 'F', long, value_name = "FORMAT")]
     pub output_type: Option<CompressionFormat>,
 
-    /// Number of threads to use in kraken2
+    /// Number of threads to use in kraken2 and optional output compression. Must >0.
     #[arg(short, long, value_name = "INT", default_value = "1")]
-    threads: usize,
+    threads: NonZeroU32,
 
     /// Set the logging level to verbose
     #[arg(short, long)]
@@ -252,9 +253,9 @@ fn main() -> Result<()> {
     // if we have one output file and multiple threads, we pass all threads to the compression command
     // if we have two output files, we pass half the threads to each compression command
     let threads = if outputs.len() == 1 {
-        args.threads
+        args.threads.get()
     } else {
-        args.threads / 2
+        args.threads.get() / 2
     };
 
     // if we have two output files and two or more threads, compress them in parallel

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ use clap::Parser;
 use env_logger::Builder;
 use lazy_static::lazy_static;
 use log::{debug, error, info, warn, LevelFilter};
+use nohuman::compression::CompressionFormat;
 use nohuman::{
     check_path_exists, download::download_database, validate_db_directory, CommandRunner,
 };
@@ -51,6 +52,13 @@ struct Args {
     /// Path to the database
     #[arg(short = 'D', long = "db", value_name = "PATH", default_value = &**DEFAULT_DB_LOCATION)]
     database: PathBuf,
+
+    /// Output compression format. u: uncompressed; b: Bzip2; g: Gzip; x: Xz (Lzma); z: Zstd
+    ///
+    /// If not provided, the format will be inferred from the given output file name(s), or the
+    /// format of the input file(s) if no output file name(s) are given.
+    #[clap(short = 'F', long, value_name = "FORMAT")]
+    pub output_type: Option<CompressionFormat>,
 
     /// Number of threads to use in kraken2
     #[arg(short, long, value_name = "INT", default_value = "1")]
@@ -139,10 +147,21 @@ fn main() -> Result<()> {
         temp_kraken_output.path().to_str().unwrap(),
     ];
     match input.len() {
+        0 => bail!("No input files provided"),
         2 => kraken_cmd.push("--paired"),
         i if i > 2 => bail!("Only one or two input files are allowed"),
         _ => {}
     }
+
+    // safe to do this as we know the input vector is not empty
+    let output_compression = if let Some(format) = args.output_type {
+        Ok(format)
+    } else if let Some(out1) = &args.out1 {
+        CompressionFormat::from_path(out1)
+    } else {
+        let mut reader = std::io::BufReader::new(std::fs::File::open(&input[0])?);
+        CompressionFormat::from_reader(&mut reader)
+    }?;
 
     // create a temporary output directory in the current directory and don't delete it
     let tmpdir = tempfile::Builder::new()
@@ -163,57 +182,98 @@ fn main() -> Result<()> {
     kraken.run(&kraken_cmd).context("Failed to run kraken2")?;
     info!("Kraken2 finished. Organising output...");
 
-    if input.len() == 2 {
+    let outputs = if input.len() == 2 {
         let out1 = args.out1.unwrap_or_else(|| {
             let parent = input[0].parent().unwrap();
             // get the part of the file name before the extension.
             // if the file is compressed, the extension will be .gz, we want to remove this first before getting the file stem
-            let fname = if input[0].extension().unwrap_or_default() == "gz" {
+            let ext = CompressionFormat::from_path(&input[0])
+                .unwrap_or_default()
+                .to_string();
+            let fname = if input[0].extension().unwrap_or_default() == ext.as_str() {
                 let no_ext = input[0].with_extension("");
                 no_ext.file_stem().unwrap().to_owned()
             } else {
                 input[0].file_stem().unwrap().to_owned()
             };
             let fname = format!("{}.nohuman.fq", fname.to_string_lossy());
-            parent.join(fname)
+            let fname = parent.join(fname);
+            output_compression.add_extension(&fname)
         });
         let out2 = args.out2.unwrap_or_else(|| {
             let parent = input[1].parent().unwrap();
             // get the part of the file name before the extension.
             // if the file is compressed, the extension will be .gz, we want to remove this first before getting the file stem
-            let fname = if input[1].extension().unwrap_or_default() == "gz" {
+            let ext = CompressionFormat::from_path(&input[1])
+                .unwrap_or_default()
+                .to_string();
+            let fname = if input[1].extension().unwrap_or_default() == ext.as_str() {
                 let no_ext = input[1].with_extension("");
                 no_ext.file_stem().unwrap().to_owned()
             } else {
                 input[1].file_stem().unwrap().to_owned()
             };
             let fname = format!("{}.nohuman.fq", fname.to_string_lossy());
-            parent.join(fname)
+            let fname = parent.join(fname);
+            output_compression.add_extension(&fname)
         });
         let tmpout1 = tmpdir.path().join("kraken_out_1.fq");
         let tmpout2 = tmpdir.path().join("kraken_out_2.fq");
+        vec![(tmpout1, out1), (tmpout2, out2)]
         // move the output files to the correct location
-        std::fs::rename(tmpout1, &out1).unwrap();
-        std::fs::rename(tmpout2, &out2).unwrap();
-        info!("Output files written to: {:?} and {:?}", &out1, &out2);
+        // std::fs::rename(tmpout1, &out1).unwrap();
+        // std::fs::rename(tmpout2, &out2).unwrap();
+        // info!("Output files written to: {:?} and {:?}", &out1, &out2);
     } else {
         let out1 = args.out1.unwrap_or_else(|| {
             let parent = input[0].parent().unwrap();
             // get the part of the file name before the extension.
             // if the file is compressed, the extension will be .gz, we want to remove this first before getting the file stem
-            let fname = if input[0].extension().unwrap_or_default() == "gz" {
+            let ext = CompressionFormat::from_path(&input[0])
+                .unwrap_or_default()
+                .to_string();
+            let fname = if input[0].extension().unwrap_or_default() == ext.as_str() {
                 let no_ext = input[0].with_extension("");
                 no_ext.file_stem().unwrap().to_owned()
             } else {
                 input[0].file_stem().unwrap().to_owned()
             };
             let fname = format!("{}.nohuman.fq", fname.to_string_lossy());
-            parent.join(fname)
+            let fname = parent.join(fname);
+            output_compression.add_extension(&fname)
         });
         let tmpout1 = tmpdir.path().join("kraken_out.fq");
+        vec![(tmpout1, out1)]
         // move the output files to the correct location
-        std::fs::rename(tmpout1, &out1).unwrap();
-        info!("Output file written to: {:?}", &out1);
+        // std::fs::rename(tmpout1, &out1).unwrap();
+        // info!("Output file written to: {:?}", &out1);
+    };
+
+    // if we have one output file and multiple threads, we pass all threads to the compression command
+    // if we have two output files, we pass half the threads to each compression command
+    let threads = if outputs.len() == 1 {
+        args.threads
+    } else {
+        args.threads / 2
+    };
+
+    // if we have two output files and two or more threads, compress them in parallel
+    if outputs.len() == 2 && threads > 1 {
+        let mut handles = Vec::new();
+        for (input, output) in outputs {
+            let handle =
+                std::thread::spawn(move || output_compression.compress(&input, &output, threads));
+            handles.push(handle);
+        }
+        for handle in handles {
+            handle
+                .join()
+                .map_err(|e| anyhow::anyhow!("Thread panicked: {:?}", e))??;
+        }
+    } else {
+        for (input, output) in outputs {
+            output_compression.compress(&input, &output, threads)?;
+        }
     }
 
     // cleanup the temporary directory, but only issue a warning if it fails

--- a/src/main.rs
+++ b/src/main.rs
@@ -68,6 +68,10 @@ struct Args {
     #[arg(short, long, value_name = "INT", default_value = "1")]
     threads: NonZeroU32,
 
+    /// Output human reads instead of removing them
+    #[arg(short = 'H', long = "human")]
+    keep_human_reads: bool,
+
     /// Set the logging level to verbose
     #[arg(short, long)]
     verbose: bool,
@@ -178,10 +182,17 @@ fn main() -> Result<()> {
         tmpdir.path().join("kraken_out.fq")
     };
     let outfile = outfile.to_string_lossy().to_string();
-    kraken_cmd.extend(&["--unclassified-out", &outfile]);
+
+    if args.keep_human_reads {
+        kraken_cmd.extend(&["--classified-out", &outfile]);
+        info!("Keeping human reads...");
+    } else {
+        kraken_cmd.extend(&["--unclassified-out", &outfile]);
+        info!("Removing human reads...");
+    }
 
     kraken_cmd.extend(input.iter().map(|p| p.to_str().unwrap()));
-    info!("Running kraken2...");
+    debug!("Running kraken2...");
     debug!("With arguments: {:?}", &kraken_cmd);
     kraken.run(&kraken_cmd).context("Failed to run kraken2")?;
     info!("Kraken2 finished. Organising output...");


### PR DESCRIPTION
This PR adds optional output compression and also add kraken2 stats to the log and adds a flag to keep human reads instead of removing them.

A HUGE thank you to [@charlesfoster](https://github.com/charlesfoster) for getting the ball rolling on this in #7.